### PR TITLE
Add ome_types to metadata

### DIFF
--- a/src/napari_bioformats/_plugin.py
+++ b/src/napari_bioformats/_plugin.py
@@ -79,6 +79,7 @@ def _reader_function(path: PathOrPaths) -> list[LayerData]:
             "channel_axis": channel_axis,
             "name": f"{fname} (Series {i})",
             "scale": scale,
+            "metadata": {"ome_types": ome_meta},
         }
 
         layers.append((data, kwargs, "image"))


### PR DESCRIPTION
Since bffile depends on ome_types the super cool tree widget is already installed!
Let's populate it with metadata -- one of the real advantages of using bioformats is getting all of that metadata.